### PR TITLE
Add shared input sanitizer

### DIFF
--- a/datingtips.php
+++ b/datingtips.php
@@ -1,19 +1,24 @@
 <?php 
 	define("TITLE", "Datingtips");
 
-  	include('includes/array_tips.php');
-  	include('includes/array_prov.php');
-	include('includes/header.php');
+        include('includes/array_tips.php');
+        include('includes/array_prov.php');
+        include('includes/utils.php');
 
-	function strip_bad_chars( $input ) {
-		$output = preg_replace( "/[^a-zA-Z0-9_-]/", "",$input);
-		return $output;
-	}
-	
-	if(isset($_GET['tip'])) {
-		$datingtip = strip_bad_chars( $_GET['tip'] );
-		$tips = $datingtips[$datingtip];
-	}
+        if(isset($_GET['tip'])) {
+                $datingtip = strip_bad_chars( $_GET['tip'] );
+                if (array_key_exists($datingtip, $datingtips)) {
+                        $tips = $datingtips[$datingtip];
+                } else {
+                        include('404.php');
+                        exit;
+                }
+        } else {
+                include('404.php');
+                exit;
+        }
+
+        include('includes/header.php');
 ?>
 
 <div class="container">

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -1,0 +1,5 @@
+<?php
+function strip_bad_chars($input) {
+    return preg_replace("/[^a-zA-Z0-9_-]/", "", $input);
+}
+?>

--- a/provincie.php
+++ b/provincie.php
@@ -1,17 +1,22 @@
 <?php 
 
   include('includes/array_prov.php');
-	include('includes/header.php');
+  include('includes/utils.php');
 
-	function strip_bad_chars( $input ) {
-		$output = preg_replace( "/[^a-zA-Z0-9_-]/", "",$input);
-		return $output;
-	}
-	
-	if(isset($_GET['item'])) {
-		$provincie = strip_bad_chars( $_GET['item'] );
-		$zoek = $provincies[$provincie];
-	}
+  if(isset($_GET['item'])) {
+    $provincie = strip_bad_chars($_GET['item']);
+    if (array_key_exists($provincie, $provincies)) {
+      $zoek = $provincies[$provincie];
+    } else {
+      include('404.php');
+      exit;
+    }
+  } else {
+    include('404.php');
+    exit;
+  }
+
+  include('includes/header.php');
 ?>
 	
 	<div class="container">


### PR DESCRIPTION
## Summary
- define `strip_bad_chars` in new `includes/utils.php`
- reuse `strip_bad_chars` in `provincie.php` and `datingtips.php`
- validate query parameters with `array_key_exists` and show 404 when missing

## Testing
- `php` (syntax check unavailable)

------
https://chatgpt.com/codex/tasks/task_e_68498958a83883249e306dd64f4d41b1