### PR TITLE
Refactor header config and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ php -S localhost:8000
 
 The project uses a few hard coded URLs that may need to be adjusted for different environments:
 
-- **Base URL** – defined in `includes/header.php` as `$baseUrl`. Set this to the public domain used for deployment so canonical links are generated correctly.
+- **Base URL** – configure via the `BASE_URL` environment variable or edit `includes/config.php`. This value is referenced when generating canonical and Open Graph URLs.
 - **API endpoints** – various pages define `api_url` JavaScript variables (see `index.php`, `profile.php` and `provincie.php`). Update these values to point to your own API server.
 
 ## Running locally

--- a/includes/config.php
+++ b/includes/config.php
@@ -1,0 +1,3 @@
+<?php
+$BASE_URL = getenv('BASE_URL') ?: 'https://datingnebenan.de';
+?>

--- a/includes/header.php
+++ b/includes/header.php
@@ -34,23 +34,43 @@
     <link rel="icon" type="image/png" sizes="16x16" href="img/fav/android-chrome-512x512.png">
     <link rel="manifest" href="img/fav/site.webmanifest">
     <?php
-        $baseUrl = "https://datingnebenan.de"; // Consistent Base URL
-        if(isset($_GET['item']) && !empty($_GET['item'])){
-          $item = htmlspecialchars($_GET['item']);
-          echo '<link rel="canonical" href="' . $baseUrl . '/dating-' . $item . '" >';
-          echo '<title>Dating ' . $item . ' | Dating Nebenan</title>';
-        } else if(isset($_GET['id']) && !empty($_GET['id'])){
-          $id = htmlspecialchars($_GET['id']);
-          echo '<link rel="canonical" href="' . $baseUrl . '/profile?id=' . $id . '" >';
-          echo '<title>Daten mit ' . $id . ' | Dating Nebenan</title>';
-        } else if(isset($_GET['tip']) && !empty($_GET['tip'])){
-          $tip = htmlspecialchars($_GET['tip']);
-          echo '<link rel="canonical" href="' . $baseUrl . '/datingtips-' . $tip . '" >';
-          echo '<title>Datingtips ' . $tip . ' | Dating Nebenan</title>';
-        } else {
-          echo '<link rel="canonical" href="' . $baseUrl . '" >';
-          echo '<title>Dating Nebenan – Finde Liebe Direkt Um Die Ecke</title>';
+        include_once('includes/config.php');
+        $pageMeta = [
+            'item' => [
+                'param' => 'item',
+                'url'   => '/dating-%s',
+                'title' => 'Dating %s | ' . $companyName
+            ],
+            'id'   => [
+                'param' => 'id',
+                'url'   => '/profile?id=%s',
+                'title' => 'Daten mit %s | ' . $companyName
+            ],
+            'tip'  => [
+                'param' => 'tip',
+                'url'   => '/datingtips-%s',
+                'title' => 'Datingtips %s | ' . $companyName
+            ],
+        ];
+
+        $canonical = $BASE_URL;
+        $title     = 'Dating Nebenan – Finde Liebe Direkt Um Die Ecke';
+
+        foreach ($pageMeta as $meta) {
+            $param = $meta['param'];
+            if (isset($_GET[$param]) && !empty($_GET[$param])) {
+                $value     = htmlspecialchars($_GET[$param]);
+                $canonical = $BASE_URL . sprintf($meta['url'], $value);
+                $title     = sprintf($meta['title'], $value);
+                break;
+            }
         }
+
+        echo '<link rel="canonical" href="' . $canonical . '" >';
+        echo '<meta property="og:url" content="' . $canonical . '">';
+        echo '<meta property="og:title" content="' . $title . '">';
+        echo '<meta property="og:type" content="website">';
+        echo '<title>' . $title . '</title>';
     ?>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZGF9E4WFZD" nonce="2726c7f26c" SameSite=None; Secure></script>
@@ -70,7 +90,7 @@
         <!-- Navigation -->
         <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
             <div class="container">
-                <a class="navbar-brand" href="https://datingnebenan.de/">Dating Nebenan</a>
+                <a class="navbar-brand" href="<?php echo $BASE_URL; ?>/">Dating Nebenan</a>
                 <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">Menü</button>
                 <div class="collapse navbar-collapse" id="navbarResponsive">
                     <?php  include('includes/nav.php'); ?>

--- a/includes/partner_links.php
+++ b/includes/partner_links.php
@@ -1,0 +1,10 @@
+<?php
+$partnerLinks = [
+    ['url' => 'https://18date.net/', 'label' => '18date.net'],
+    ['url' => 'https://sex55.net/', 'label' => 'sex55.net'],
+    ['url' => 'https://shemaledaten.net/', 'label' => 'shemaledaten.net'],
+    ['url' => 'https://datingnebenan.de/', 'label' => 'Dating Nebenan'],
+    ['url' => 'https://example.com/', 'label' => 'Example Partner'],
+    ['url' => 'https://another-example.com/', 'label' => 'Another Partner'],
+];
+?>

--- a/index.php
+++ b/index.php
@@ -26,7 +26,7 @@
     <div class="row" v-cloak>
         <div class="col-lg-3 col-md-6 mb-4 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
             <div class="card h-100">
-                <a :href="'profile.php?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in Flevoland'"></a>
+                <a :href="'profile.php?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in Flevoland'" @error="imgError"></a>
                 <div class="card-body">
                     <div class="card-top">
                         <h4 class="card-title">{{ profile.name }}</h4>  

--- a/partnerlinks.php
+++ b/partnerlinks.php
@@ -1,29 +1,26 @@
 <?php
-	define('TITLE', 'Partnerlinks');
-	include('includes/header.php');
+        define('TITLE', 'Partnerlinks');
+        include('includes/header.php');
+        include('includes/partner_links.php');
+
+        $columns = array_chunk($partnerLinks, ceil(count($partnerLinks) / 3));
 ?>
 <div class="container">
-	<div class="jumbotron my-4">
-		<h1 class="text-center">Partner-Links:</h1>
-		<div class="row">
-			<div class="col-md-6 col-12">
-				<ul>
-					
-				</ul>
-			</div>
-			<div class="col-md-6 col-12">
-				<ul>
-					
-				</ul>
-			</div>
-			<div class="col-md-6 col-12">
-				<ul>
-					
-				</ul>
-			</div>
-		</div>
-	</div>
+        <div class="jumbotron my-4">
+                <h1 class="text-center">Partner-Links:</h1>
+                <div class="row">
+                        <?php foreach ($columns as $col): ?>
+                        <div class="col-md-6 col-12">
+                                <ul>
+                                <?php foreach ($col as $link): ?>
+                                        <li><a href="<?php echo htmlspecialchars($link['url']); ?>" target="_blank"><?php echo htmlspecialchars($link['label']); ?></a></li>
+                                <?php endforeach; ?>
+                                </ul>
+                        </div>
+                        <?php endforeach; ?>
+                </div>
+        </div>
 </div>
 <?php
-	include('includes/footer.php');
+        include('includes/footer.php');
 ?>

--- a/profile.php
+++ b/profile.php
@@ -9,7 +9,7 @@
         <hr>
         <div class="row">
             <div class="col-sm-4 text-center">
-                <img class="profile-pic" :src="profile.profile_image_big" :alt="'Dating im ' + profile.province + ' mit ' + profile.name" :title="'Profilbild von ' + profile.name">
+                <img class="profile-pic" :src="profile.profile_image_big" :alt="'Dating im ' + profile.province + ' mit ' + profile.name" :title="'Profilbild von ' + profile.name" @error="imgError">
             </div>
             <div class="col-sm-8">
                 <h4>Über {{ profile.name }}:</h4>

--- a/provincie.php
+++ b/provincie.php
@@ -32,7 +32,7 @@
            v-for="profile in filtered_profiles"
           >
         <div class="card h-100">
-            <a :href="'profile.php?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="'Dating in ' + profile.province + ' mit ' + profile.name" :title="'Siehe das Profil von ' + profile.name + ' aus ' + profile.city"></a>
+            <a :href="'profile.php?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="'Dating in ' + profile.province + ' mit ' + profile.name" :title="'Siehe das Profil von ' + profile.name + ' aus ' + profile.city" @error="imgError"></a>
             <div class="card-body">
             	<div class="card-top">
                   <h4 class="card-title">{{ profile.name }}</h4>  


### PR DESCRIPTION
## Summary
- load BASE_URL from new `includes/config.php`
- simplify canonical/Open Graph logic with associative array
- expose BASE_URL in navigation brand link
- add partner link list generation from data array
- show fallback images on error
- document new BASE_URL config

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498ccb6f748324b993557f2025ee3f