### PR TITLE
Update canonical URLs and profile links

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -53,8 +53,9 @@
             ],
         ];
 
-        $canonical = $BASE_URL;
-        $title     = 'Dating Nebenan – Finde Liebe Direkt Um Die Ecke';
+        $baseUrl       = $BASE_URL;
+        $canonical     = $baseUrl;
+        $title         = 'Dating Nebenan – Finde Liebe Direkt Um Die Ecke';
 
         foreach ($pageMeta as $meta) {
             $param = $meta['param'];
@@ -63,6 +64,28 @@
                 $canonical = $BASE_URL . sprintf($meta['url'], $value);
                 $title     = sprintf($meta['title'], $value);
                 break;
+            }
+        }
+
+        if (isset($_GET['id']) && !empty($_GET['id'])) {
+            $id        = (int) $_GET['id'];
+            $apiUrl    = "https://23mlf01ccde23.com/profile/get0/8/" . $id;
+            $response  = @file_get_contents($apiUrl);
+            if ($response !== false) {
+                $data = json_decode($response, true);
+                $profileName = null;
+                if (isset($data['profile']['name'])) {
+                    $profileName = $data['profile']['name'];
+                } elseif (isset($data['name'])) {
+                    $profileName = $data['name'];
+                }
+                if ($profileName) {
+                    $slug      = strtolower($profileName);
+                    $slug      = preg_replace('/[^a-z0-9]+/', '-', $slug);
+                    $slug      = trim($slug, '-');
+                    $canonical = $baseUrl . '/daten-met-' . $slug;
+                    $title     = 'Daten met ' . $profileName;
+                }
             }
         }
 

--- a/index.php
+++ b/index.php
@@ -26,7 +26,7 @@
     <div class="row" v-cloak>
         <div class="col-lg-3 col-md-6 mb-4 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
             <div class="card h-100">
-                <a :href="'profile.php?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in Flevoland'" @error="imgError"></a>
+                <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in Flevoland'" @error="imgError"></a>
                 <div class="card-body">
                     <div class="card-top">
                         <h4 class="card-title">{{ profile.name }}</h4>  
@@ -38,7 +38,7 @@
                         <li class="list-group-item">Bundesland: {{ profile.province }}</li>
                     </ul>
                 </div>
-                <a :href="'profile.php?id=' + profile.id" class="card-footer btn btn-primary">Profil ansehen</a>
+                <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id" class="card-footer btn btn-primary">Profil ansehen</a>
             </div>
         </div>
         <script nonce="2726c7f26c">

--- a/js/oproepjes.js
+++ b/js/oproepjes.js
@@ -1,3 +1,13 @@
+function slugify(text){
+    return text.toString().toLowerCase()
+        .replace(/\s+/g,'-')
+        .replace(/[^a-z0-9-]/g,'')
+        .replace(/--+/g,'-')
+        .replace(/^-+|-+$/g,'');
+}
+
+window.slugify = slugify;
+
 var oproepjes= new Vue({
     el: "#oproepjes",
     created: function(){
@@ -42,13 +52,7 @@ var oproepjes= new Vue({
         imgError: function(event){
             event.target.src = 'img/fallback.svg';
         },
-        slugify: function(text){
-            return text.toString().toLowerCase()
-                .replace(/\s+/g,'-')
-                .replace(/[^a-z0-9-]/g,'')
-                .replace(/--+/g,'-')
-                .replace(/^-+|-+$/g,'');
-        },
+        slugify: slugify,
         set_page_number: function(page){
             if(page <= 1){
                 this.page= 1;

--- a/provincie.php
+++ b/provincie.php
@@ -32,7 +32,7 @@
            v-for="profile in filtered_profiles"
           >
         <div class="card h-100">
-            <a :href="'profile.php?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="'Dating in ' + profile.province + ' mit ' + profile.name" :title="'Siehe das Profil von ' + profile.name + ' aus ' + profile.city" @error="imgError"></a>
+            <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="'Dating in ' + profile.province + ' mit ' + profile.name" :title="'Siehe das Profil von ' + profile.name + ' aus ' + profile.city" @error="imgError"></a>
             <div class="card-body">
             	<div class="card-top">
                   <h4 class="card-title">{{ profile.name }}</h4>  
@@ -44,7 +44,7 @@
                 <li class="list-group-item">Bundesland: {{ profile.province }}</li>
               </ul>
             </div>
-            <a :href="'profile.php?id=' + profile.id" class="card-footer btn btn-primary">Profil ansehen</a></div>
+            <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id" class="card-footer btn btn-primary">Profil ansehen</a></div>
         </div>
       </div>
       <script nonce="2726c7f26c">


### PR DESCRIPTION
## Summary
- fetch profile details to customize canonical URL
- expose a `slugify` helper and use it for profile links
- link cards to `daten-met-<name>?id=<id>` in listings

## Testing
- `php -l includes/header.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498e557674832494651dcd73ff3c2a