### PR TITLE
Update profile slugs to date-mit

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -39,7 +39,7 @@
             'id'   => [
                 'param' => 'id',
                 'url'   => '/profile?id=%s',
-                'title' => 'Daten mit %s | ' . $companyName
+                'title' => 'Date met %s | ' . $companyName
             ],
             'tip'  => [
                 'param' => 'tip',
@@ -78,8 +78,8 @@
                     $slug      = strtolower($profileName);
                     $slug      = preg_replace('/[^a-z0-9]+/', '-', $slug);
                     $slug      = trim($slug, '-');
-                    $canonical = $baseUrl . '/daten-met-' . $slug;
-                    $title     = 'Daten met ' . $profileName;
+                    $canonical = $baseUrl . '/date-mit-' . $slug;
+                    $title     = 'Date met ' . $profileName;
                 }
             }
         }

--- a/index.php
+++ b/index.php
@@ -26,7 +26,7 @@
     <div class="row" v-cloak>
         <div class="col-lg-3 col-md-6 mb-4 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
             <div class="card h-100">
-                <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in Flevoland'" @error="imgError"></a>
+                <a :href="'date-mit-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in Flevoland'" @error="imgError"></a>
                 <div class="card-body">
                     <div class="card-top">
                         <h4 class="card-title">{{ profile.name }}</h4>  
@@ -38,7 +38,7 @@
                         <li class="list-group-item">Bundesland: {{ profile.province }}</li>
                     </ul>
                 </div>
-                <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id" class="card-footer btn btn-primary">Profil ansehen</a>
+                <a :href="'date-mit-' + slugify(profile.name) + '?id=' + profile.id" class="card-footer btn btn-primary">Profil ansehen</a>
             </div>
         </div>
         <script nonce="2726c7f26c">

--- a/provincie.php
+++ b/provincie.php
@@ -32,7 +32,7 @@
            v-for="profile in filtered_profiles"
           >
         <div class="card h-100">
-            <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="'Dating in ' + profile.province + ' mit ' + profile.name" :title="'Siehe das Profil von ' + profile.name + ' aus ' + profile.city" @error="imgError"></a>
+            <a :href="'date-mit-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="'Dating in ' + profile.province + ' mit ' + profile.name" :title="'Siehe das Profil von ' + profile.name + ' aus ' + profile.city" @error="imgError"></a>
             <div class="card-body">
             	<div class="card-top">
                   <h4 class="card-title">{{ profile.name }}</h4>  
@@ -44,7 +44,7 @@
                 <li class="list-group-item">Bundesland: {{ profile.province }}</li>
               </ul>
             </div>
-            <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id" class="card-footer btn btn-primary">Profil ansehen</a></div>
+            <a :href="'date-mit-' + slugify(profile.name) + '?id=' + profile.id" class="card-footer btn btn-primary">Profil ansehen</a></div>
         </div>
       </div>
       <script nonce="2726c7f26c">


### PR DESCRIPTION
## Summary
- adjust header title to say "Date met {profileName}"
- generate canonical profile URLs using the `date-mit` slug
- update profile links on landing page to use the new slug
- update province listing links to use the new slug

## Testing
- `grep -R "daten-met" -n`

------
https://chatgpt.com/codex/tasks/task_e_68499a34f6f88324a70022e6cf5a0d7a