### PR TITLE
Fix datingtips menu slug

### DIFF
--- a/includes/nav_items.php
+++ b/includes/nav_items.php
@@ -70,10 +70,10 @@
 
 	$navItems2 = array(
 
-					array(
-						'slug' => 'datingtipps',
-						'title' => 'Datingtipps'
-					),
+                                        array(
+                                                'slug' => 'datingtips',
+                                                'title' => 'Datingtipps'
+                                        ),
 					array(
 						'slug' => 'gratis-dating',
 						'title' => 'Gratis-Dating'


### PR DESCRIPTION
## Summary
- link `Datingtipps` menu item to `datingtips.php`

## Testing
- `php` not installed, so no syntax check

------
https://chatgpt.com/codex/tasks/task_e_685152a7754c832481152a71b3b0f073