### PR TITLE
Fix baseUrl reference in navbar

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -201,7 +201,7 @@
         <!-- Navigation -->
         <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
             <div class="container">
-                <a class="navbar-brand" href="<?php echo $BASE_URL; ?>/">Dating Nebenan</a>
+                <a class="navbar-brand" href="<?php echo $baseUrl; ?>/">Dating Nebenan</a>
                 <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">Menü</button>
                 <div class="collapse navbar-collapse" id="navbarResponsive">
                     <?php  include('includes/nav.php'); ?>


### PR DESCRIPTION
## Summary
- use `$baseUrl` variable for navbar home link

## Testing
- `php -l includes/header.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68529eba7738832485fee3a8ae9fcf5b