### PR TITLE
Fix dating tip links

### DIFF
--- a/datingtips.php
+++ b/datingtips.php
@@ -6,9 +6,13 @@
         include('includes/header.php');
         include('includes/utils.php');
 
-        if(isset($_GET['tip'])) {
-                $datingtip = strip_bad_chars( $_GET['tip'] );
-                $tips = $datingtips[$datingtip];
+        if (isset($_GET['tip'])) {
+                $datingtip = strip_bad_chars($_GET['tip']);
+                if (!empty($datingtip) && isset($datingtips[$datingtip]) && !empty($datingtips[$datingtip]['name'])) {
+                        $tips = $datingtips[$datingtip];
+                } else {
+                        $tips = ['title' => '', 'tekst' => ''];
+                }
         }
 ?>
 

--- a/includes/array_tips.php
+++ b/includes/array_tips.php
@@ -1,47 +1,23 @@
-<?php 
-	// Provincies
-	$datingtips = array(
+<?php
+        // Datingtipps
+        $datingtips = array(
+                                        "profil-erstellen" => array(
 
-					"" => array(
+                                                'name' =>       "Profil erstellen",
+                                                'title' =>      "Erstelle ein aussagekräftiges Profil",
+                                                'tekst' =>      "<p>Ein detailliertes Profil mit echten Fotos erhöht deine Chancen auf ein Match.</p>",
+                                                ),
+                                        "ehrlich-schreiben" => array(
 
-						'name' => 	"",
-						'title' => 	"",
-						'tekst' => 	""
-						),
-					"" => array(
+                                                'name' =>       "Ehrlich schreiben",
+                                                'title' =>      "Bleibe authentisch",
+                                                'tekst' =>      "<p>Ehrliche Nachrichten schaffen Vertrauen von Anfang an.</p>",
+                                                ),
+                                        "sicher-treffen" => array(
 
-						'name' => 	"",
-						'title' => 	"",
-						'tekst' => 	""
-						),
-					"" => array(
+                                                'name' =>       "Sicheres erstes Treffen",
+                                                'title' =>      "Trefft euch an öffentlichen Orten",
+                                                'tekst' =>      "<p>Wähle für das erste Date einen öffentlichen Ort und informiere Freunde darüber.</p>",
+                                                ),
+                                        );
 
-						'name' => 	"",
-						'title' => 	"",
-						'tekst' => 	""
-						),
-					"" => array(
-
-						'name' => 	"",
-						'title' => 	"",
-						'tekst' => 	""
-						),
-					"" => array(
-
-						'name' => 	"",
-						'title' => 	"",
-						'tekst' => 	""
-						),
-					"" => array(
-
-						'name' => 	"",
-						'title' => 	"",
-						'tekst' => 	""
-						),
-					"" => array(
-
-						'name' => 	"",
-						'title' => 	"",
-						'tekst' => 	""
-						),
-					);

--- a/index.php
+++ b/index.php
@@ -87,8 +87,12 @@
     </div>
     <div class="jumbotron text-center">
         <h2>Dating-Tipps</h2>
-        <?php foreach ($datingtips as $tips => $item) { ?>
-        <a href="datingtips-<?php echo $tips; ?>" class="btn btn-primary btn-tips"><?php echo $item['name']; ?></a>
+        <?php foreach ($datingtips as $slug => $item) {
+            if (empty($slug) || empty($item['name'])) {
+                continue;
+            }
+        ?>
+        <a href="datingtips-<?php echo $slug; ?>" class="btn btn-primary btn-tips"><?php echo $item['name']; ?></a>
         <?php } ?>
     </div>
     <div id="footer-banner"></div>


### PR DESCRIPTION
## Summary
- fill `array_tips.php` with real tips
- ignore empty slugs when building dating-tip links
- guard against empty tip slugs in `datingtips.php`

## Testing
- `php -l includes/array_tips.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852a014370c83249f27aef38709ecab