### PR TITLE
Fix default header when tip missing

### DIFF
--- a/datingtips.php
+++ b/datingtips.php
@@ -13,6 +13,8 @@
                 } else {
                         $tips = ['title' => '', 'tekst' => ''];
                 }
+        } else {
+                $tips = ['title' => 'Datingtipps', 'tekst' => ''];
         }
 ?>
 


### PR DESCRIPTION
## Summary
- show the default header 'Datingtipps' when visiting `datingtips.php` without a `tip` query parameter

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852a2c5c25c8324bdd34eaad5e4a507