### PR TITLE
Fix land.php switch and templates

### DIFF
--- a/land.php
+++ b/land.php
@@ -5,22 +5,25 @@
     $land = isset($_GET['land']) ? strip_bad_chars($_GET['land']) : '';
     switch ($land) {
         case 'de':
-            $provinces = $de;
+            $provArray = $de;
+            $landInfo  = $deLand;
             $landTitle = 'Deutschland';
             break;
         case 'at':
-            $provinces = $at;
+            $provArray = $at;
+            $landInfo  = $atLand;
             $landTitle = 'Österreich';
             break;
         case 'ch':
-            $provinces = $ch;
+            $provArray = $ch;
+            $landInfo  = $chLand;
             $landTitle = 'Schweiz';
             break;
         default:
-            $provinces = [];
+            $provArray = [];
+            $landInfo  = [];
             $landTitle = '';
     }
-
     if (empty($landTitle)) {
         header('Location: 404.php');
         exit;
@@ -30,7 +33,7 @@
     include('includes/header.php');
 ?>
 <div class="container">
-    <div class="jumbotron my-4" id="<?php echo $info['id']; ?>">
+    <div class="jumbotron my-4" >
         <h1 class="text-center"><?php echo $landInfo['title']; ?></h1>
         <hr>
         <p><?php echo $landInfo['intro']; ?></p>


### PR DESCRIPTION
## Summary
- fix switch blocks to assign `$provArray` and `$landInfo`
- remove invalid jumbotron id
- use `$provArray` for province loop

## Testing
- `php -l land.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685bdafc3de083248eb48617c743fd78