### PR TITLE
Add router for PHP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ This repository contains the source code for **Dating Nebenan**, a small PHP and
 
 1. Ensure you have PHP 7.4 or higher installed.
 2. Clone this repository and install dependencies (none are required outside of the provided `vendor` directory).
-3. Start a development server from the project root:
+3. Start a development server from the project root using the provided
+   `router.php` so that pretty URLs are rewritten correctly:
 
 ```bash
-php -S localhost:8000
+php -S localhost:8000 router.php
 ```
 
 4. Visit `http://localhost:8000` in your browser.
@@ -23,4 +24,7 @@ The project uses a few hard coded URLs that may need to be adjusted for differen
 
 ## Running locally
 
-After updating the URLs if necessary, launch the built‑in PHP server as shown above. The site should load locally with fully static assets and API calls hitting the configured endpoints.
+After updating the URLs if necessary, launch the built‑in PHP server with
+`router.php` to enable URL rewriting as shown above. The site should load
+locally with fully static assets and API calls hitting the configured
+endpoints.

--- a/router.php
+++ b/router.php
@@ -1,0 +1,54 @@
+<?php
+$path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+$path = rawurldecode($path);
+
+$fullPath = __DIR__ . $path;
+if ($path !== '/' && file_exists($fullPath)) {
+    return false; // serve the requested resource as-is
+}
+
+// /dating-<slug> => provincie.php?item=<slug>
+if (preg_match('#^/dating-([^/]+)$#', $path, $m)) {
+    $_GET['item'] = $m[1];
+    include __DIR__ . '/provincie.php';
+    return;
+}
+
+// /date-mit-<slug> => profile.php?slug=<slug>
+if (preg_match('#^/date-mit-([^/]+)$#', $path, $m)) {
+    $_GET['slug'] = $m[1];
+    include __DIR__ . '/profile.php';
+    return;
+}
+
+// /datingtips-<slug> => datingtips.php?tip=<slug>
+if (preg_match('#^/datingtips-([^/]+)$#', $path, $m)) {
+    $_GET['tip'] = $m[1];
+    include __DIR__ . '/datingtips.php';
+    return;
+}
+
+$routes = [
+    '/'              => 'index.php',
+    '/index'         => 'index.php',
+    '/partnerlinks'  => 'partnerlinks.php',
+    '/privacy'       => 'privacy.php',
+    '/cookie-policy' => 'cookie-policy.php',
+    '/datingtips'    => 'datingtips.php',
+    '/land'          => 'land.php',
+];
+
+if (isset($routes[$path])) {
+    include __DIR__ . '/' . $routes[$path];
+    return;
+}
+
+$phpFile = __DIR__ . $path . '.php';
+if ($path !== '/' && file_exists($phpFile)) {
+    include $phpFile;
+    return;
+}
+
+http_response_code(404);
+include __DIR__ . '/404.php';
+


### PR DESCRIPTION
## Summary
- provide routing rules for PHP development server
- document using `router.php` to enable pretty URLs

## Testing
- `php -l router.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685beba3cfa883248e86a66f5a3ddd2e