### PR TITLE
Add country URLs

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -92,6 +92,14 @@
     } else if (isset($_GET['tip'])) {
         $canonicalUrl = $baseUrl . "/datingtips-" . htmlspecialchars($_GET['tip']);
         $title = "Datingtipps " . htmlspecialchars($_GET['tip']);
+    } else if (isset($_GET['land'])) {
+        $slugMap = ['de' => 'deutschland', 'at' => 'osterreich', 'ch' => 'schweiz'];
+        $titleMap = ['de' => 'Deutschland', 'at' => 'Österreich', 'ch' => 'Schweiz'];
+        $code = $_GET['land'];
+        if (isset($slugMap[$code])) {
+            $canonicalUrl = $baseUrl . '/dating-' . $slugMap[$code];
+            $title = 'Dating ' . $titleMap[$code];
+        }
     }
     // When no query parameters are present, build canonical from script name
     if (empty($_GET)) {

--- a/router.php
+++ b/router.php
@@ -7,6 +7,18 @@ if ($path !== '/' && file_exists($fullPath)) {
     return false; // serve the requested resource as-is
 }
 
+// /dating-deutschland, /dating-osterreich, /dating-schweiz => land.php?land=<code>
+$countryRoutes = [
+    '/dating-deutschland' => 'de',
+    '/dating-osterreich'  => 'at',
+    '/dating-schweiz'     => 'ch',
+];
+if (isset($countryRoutes[$path])) {
+    $_GET['land'] = $countryRoutes[$path];
+    include __DIR__ . '/land.php';
+    return;
+}
+
 // /dating-<slug> => provincie.php?item=<slug>
 if (preg_match('#^/dating-([^/]+)$#', $path, $m)) {
     $_GET['item'] = $m[1];

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -50,6 +50,21 @@
   <priority>0.64</priority>
 </url>
 <url>
+  <loc>https://datingnebenan.de/dating-deutschland</loc>
+  <lastmod>2025-06-12T00:00:00+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://datingnebenan.de/dating-osterreich</loc>
+  <lastmod>2025-06-12T00:00:00+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://datingnebenan.de/dating-schweiz</loc>
+  <lastmod>2025-06-12T00:00:00+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
   <loc>https://datingnebenan.de/dating-baden-wurttemberg</loc>
   <lastmod>2025-06-12T00:00:00+00:00</lastmod>
   <priority>0.80</priority>


### PR DESCRIPTION
## Summary
- enable pretty URLs for country pages in `router.php`
- add canonical URL handling for `land.php` pages in header
- include Germany, Austria and Switzerland pages in the sitemap

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bf281256083248b71ad0356017fd8