### PR TITLE
Update OG defaults to use canonical data

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -132,10 +132,10 @@
     // Dynamisch genereren van inhoud gebaseerd op de pagina-URL
     $current_url = "https://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
     // Mapping van URL-sleutels naar Open Graph gegevens
-    $og_title = $default_title;
+    $og_title = $title;
     $og_description = $default_description;
     $og_image = $default_image;
-    $og_url = $default_url;
+    $og_url = $canonicalUrl;
     $og_pages = [
         'dating-baden-wurttemberg' => [
             'title' => 'Dating Baden-Wurttemberg',


### PR DESCRIPTION
## Summary
- default Open Graph `og:title` to the current page title
- default Open Graph `og:url` to the canonical URL

## Testing
- `php -l includes/header.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685cfe18c2f88324a42835c787263924