### PR TITLE
Update footer to use clean policy URLs

### DIFF
--- a/includes/footer.php
+++ b/includes/footer.php
@@ -11,12 +11,12 @@
         <li><a href="partnerlinks" class="m-0">Weitere Partnerlinks...</a></li>
     </ul>
     <span class="sub-text">Impressum &copy; <?php echo date('Y'); ?> <?php echo $companyName; ?> | Finde Liebe Direkt Um Die Ecke</span>
-    <span class="policy-links sub-text"><a href="/privacy.php">Datenschutz</a> | <a href="/cookie-policy.php">Cookie-Richtlinie</a></span>
+    <span class="policy-links sub-text"><a href="/privacy">Datenschutz</a> | <a href="/cookie-policy">Cookie-Richtlinie</a></span>
 </footer>
 <!-- Cookie Consent Banner -->
 <div id="cookie-banner" style="position: fixed; bottom: 0; left: 0; right: 0; background: #fff; border-top: 1px solid #ccc; font-family: Arial, sans-serif; padding: 20px; z-index: 10000; display: none;">
   <div style="max-width: 960px; margin: auto;">
-    <p style="margin-bottom: 10px;">We use cookies to personalize content and ads, to provide social media features and to analyze our traffic. For more details, see our <a href="/cookie-policy.php" target="_blank">Cookie Policy</a>.</p>
+    <p style="margin-bottom: 10px;">We use cookies to personalize content and ads, to provide social media features and to analyze our traffic. For more details, see our <a href="/cookie-policy" target="_blank">Cookie Policy</a>.</p>
     <form id="cookie-form">
       <label><input type="checkbox" disabled checked> Necessary (required)</label><br>
       <label><input type="checkbox" id="cookie-statistics"> Statistics (e.g. Google Analytics)</label><br>


### PR DESCRIPTION
## Summary
- link to `/privacy` and `/cookie-policy` instead of the `.php` files

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cfed250e48324a7176d53df2fef5f