### PR TITLE
Fix slug capture in rewrite rule

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -9,7 +9,7 @@ RewriteRule ^(.+)$ $1.php [QSA]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
-RewriteRule ^date-mit-[^/]+/?$ profile.php [L,QSA]
+RewriteRule ^date-mit-([^/]+)/?$ profile.php?slug=$1 [L,QSA]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d


### PR DESCRIPTION
## Summary
- capture the slug in the `/date-mit-...` rewrite rule so it gets passed to `profile.php`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d1e2e46108324a1320f05ba169ece