### PR TITLE
Fix 404 handling path

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -22,7 +22,7 @@ RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^datingtips-([^/]+)/?$ datingtips.php?tip=$1 [L,QSA]
 
-ErrorDocument 404 https://datingnebenan.de/404.php
+ErrorDocument 404 /404.php
 
 <IfModule mod_deflate.c>
 AddOutputFilterByType DEFLATE text/plain


### PR DESCRIPTION
## Summary
- serve 404 page without redirect by changing ErrorDocument path

## Testing
- `php -l 404.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d203444ac8324b0d6b4447319400d