### PR TITLE
Add sitemap generation utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,12 @@ After updating the URLs if necessary, launch the built‑in PHP server with
 `router.php` to enable URL rewriting as shown above. The site should load
 locally with fully static assets and API calls hitting the configured
 endpoints.
+
+## Sitemap generation
+
+Run `generate_sitemap.php` to build `sitemap.xml` with the latest profile URLs and static routes.
+To keep the sitemap updated automatically, schedule the script via cron after new profiles are added. A daily job looks like:
+
+```cron
+0 0 * * * php /path/to/generate_sitemap.php > /dev/null 2>&1
+```

--- a/generate_sitemap.php
+++ b/generate_sitemap.php
@@ -1,0 +1,76 @@
+<?php
+require __DIR__ . '/includes/array_prov.php';
+require __DIR__ . '/includes/array_tips.php';
+$config = include __DIR__ . '/config.php';
+
+$baseUrl = getenv('ONL_BASE_URL') ?: 'https://datingnebenan.de';
+
+function slugify($text) {
+    $text = strtolower(trim($text));
+    $text = preg_replace('/[^a-z0-9]+/', '-', $text);
+    return trim($text, '-');
+}
+
+$urls = [];
+
+$static = [
+    '/',
+    '/datingtips',
+    '/partnerlinks',
+    '/privacy',
+    '/cookie-policy',
+    '/dating-deutschland',
+    '/dating-osterreich',
+    '/dating-schweiz',
+];
+foreach ($static as $path) {
+    $urls[] = $baseUrl . $path;
+}
+
+foreach (array_keys($de) as $slug) {
+    $urls[] = $baseUrl . '/dating-' . $slug;
+}
+foreach (array_keys($at) as $slug) {
+    $urls[] = $baseUrl . '/dating-' . $slug;
+}
+foreach (array_keys($ch) as $slug) {
+    $urls[] = $baseUrl . '/dating-' . $slug;
+}
+foreach (array_keys($datingtips) as $slug) {
+    $urls[] = $baseUrl . '/datingtips-' . $slug;
+}
+
+$provinceApiBase = rtrim($config['BASE_API_URL'], '/') . '/profile/province';
+$countryMap = [ 'de' => $de, 'at' => $at, 'ch' => $ch ];
+$profilePaths = [];
+foreach ($countryMap as $code => $provArr) {
+    foreach ($provArr as $prov) {
+        $endpoint = $provinceApiBase . '/' . $code . '/' . rawurlencode($prov['name']) . '/120';
+        $json = @file_get_contents($endpoint);
+        if ($json === false) continue;
+        $data = json_decode($json, true);
+        if (!$data || !isset($data['profiles'])) continue;
+        foreach ($data['profiles'] as $prof) {
+            if (empty($prof['id']) || empty($prof['name'])) continue;
+            $slug = slugify($prof['name']);
+            $profilePaths[$prof['id']] = $baseUrl . '/date-mit-' . $slug . '?id=' . $prof['id'];
+        }
+    }
+}
+foreach ($profilePaths as $url) {
+    $urls[] = $url;
+}
+
+$xml = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><urlset></urlset>');
+$xml->addAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
+$xml->addAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+$xml->addAttribute('xsi:schemaLocation', 'http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd');
+$lastMod = date('c');
+foreach ($urls as $loc) {
+    $url = $xml->addChild('url');
+    $url->addChild('loc', htmlspecialchars($loc, ENT_XML1));
+    $url->addChild('lastmod', $lastMod);
+}
+file_put_contents(__DIR__ . '/sitemap.xml', $xml->asXML());
+
+echo "Generated sitemap with " . count($urls) . " URLs\n";


### PR DESCRIPTION
## Summary
- generate sitemap.xml combining static routes and API profile links
- document how to run the script automatically

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d1fc7acbc83248532bef22dcb6359